### PR TITLE
Canonicalize lib names in deps.edn

### DIFF
--- a/tools/apigen/deps.edn
+++ b/tools/apigen/deps.edn
@@ -5,5 +5,5 @@
            org.clojure/tools.cli {:mvn/version "1.0.194"}
            org.blancas/kern      {:mvn/version "1.1.0"}
            com.rpl/specter       {:mvn/version "1.1.3"}
-           cljfmt                {:mvn/version "0.6.7"}}
+           cljfmt/cljfmt         {:mvn/version "0.6.7"}}
  :aliases {:cli {:main-opts ["-m" "apigen.cli"]}}}


### PR DESCRIPTION
Unqualified lib names are being deprecated in deps.edn and will warn